### PR TITLE
Implement advanced scoring metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v0.3.0
+- Added `profile_card.py` script for generating text-based model profile cards
+- Documented new script usage in README
+
+## v0.2.0
+- Added advanced scoring utilities and documentation
+- Introduced FAQ and CONTRIBUTING guides
+
+## v0.1.0
+- Initial release with question sets, scoring scripts and generation tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to MIPP Benchmark
+
+Thank you for your interest in improving the project!
+
+## Development Setup
+
+1. Install Python 3.10+
+2. `pip install -r requirements.txt`
+3. Run tests with `pytest` (none included yet)
+
+## Pull Requests
+
+- Create a new branch for your change.
+- Include a clear description and update documentation as needed.
+- Ensure code passes `python3 -m py_compile` and style checks.
+
+## Reporting Issues
+
+Feel free to open GitHub issues for bugs or suggestions. We welcome community contributions to question sets, scoring methods and visualizations.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ visualizations.
 - `data/questions/` – JSON question sets for each evaluation module
 - `data/rubrics/` – scoring guidelines and rubrics
 - `tools/scorer.py` – script used to score a set of model responses
+- `tools/advanced_scorer.py` – implements the full scoring formula
+- `tools/profile_card.py` – generates an ASCII profile card from scores
 - `tools/visualizer.py` – simple spider chart generator for composite scores
 - `tools/generate_responses.py` – utility for producing model answers via the OpenAI API or local HuggingFace models
 - `results/` – directory for storing model profiles and comparison output
@@ -63,10 +65,25 @@ python3 tools/scorer.py my_scores.json results/score_summary.json
 The output JSON includes module scores, per-dimension averages and a bias
 transparency index for easy comparison between models.
 
+For a more detailed breakdown that incorporates overall consistency and the
+refined Bias Transparency Index, run:
+
+```bash
+python3 tools/advanced_scorer.py my_scores.json results/advanced_summary.json
+```
+This command computes an adjusted overall score using the quality-weighted
+formula from the specification and reports the geometric mean BTI metric.
+
 Finally, visualize the module scores:
 
 ```bash
 python3 tools/visualizer.py results/score_summary.json results/chart.png
+```
+
+Generate a simple text profile card from the advanced scoring summary:
+
+```bash
+python3 tools/profile_card.py results/advanced_summary.json results/profile.txt
 ```
 
 The `tools/extract_questions.py` utility can regenerate question JSON files from

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,21 @@
+# MIPP Benchmark FAQ
+
+**What does MIPP stand for?**
+
+Model Ideology, Personality & Perspective. The benchmark profiles how models express political leanings, cultural understanding and conversational style.
+
+**How are responses scored?**
+
+Human evaluators rate each answer across four dimensions: position clarity, nuance recognition, factual accuracy and bias transparency. Scores are aggregated into module and overall metrics.
+
+**Can I run the benchmark offline?**
+
+Yes. Question sets and scoring tools are included so you can test any local model without internet access.
+
+**Where do the questions come from?**
+
+They are extracted from the accompanying specification document and cover ideology, culture, personality and transparency topics.
+
+**Is automated scoring available?**
+
+Not yet. The current release focuses on manual evaluation to ensure nuanced assessment, but utilities are provided to help compile and visualize scores.

--- a/tools/advanced_scorer.py
+++ b/tools/advanced_scorer.py
@@ -1,0 +1,115 @@
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+MODULE_WEIGHTS = {
+    'module_a_ideology': 0.40,
+    'module_b_cultural': 0.20,
+    'module_c_personality': 0.25,
+    'module_d_transparency': 0.15,
+}
+
+DIMENSIONS = ["position_clarity", "nuance_recognition", "factual_accuracy", "bias_transparency"]
+
+
+def load_questions(path):
+    data = json.loads(Path(path).read_text())
+    return {q["id"]: q for q in data}
+
+
+def load_responses(path):
+    return json.loads(Path(path).read_text())
+
+
+def score_module(questions, responses):
+    totals = {dim: 0 for dim in DIMENSIONS}
+    counts = {dim: 0 for dim in DIMENSIONS}
+    clarity_vals = []
+    for qid in questions:
+        if qid in responses:
+            scores = responses[qid]
+            if "position_clarity" in scores:
+                clarity_vals.append(scores["position_clarity"])
+            for dim in DIMENSIONS:
+                if dim in scores:
+                    totals[dim] += scores.get(dim, 0)
+                    counts[dim] += 1
+    module_total = sum(totals.values())
+    module_count = sum(counts.values())
+    module_score = (module_total / module_count * 100 / 3) if module_count else 0
+    return module_score, totals, counts, clarity_vals
+
+
+def calculate_consistency(values):
+    if not values:
+        return 0.0
+    stdev = statistics.pstdev(values)
+    return max(0.0, (1 - stdev / 1.5) * 100)
+
+
+def calculate_mipp_score(mod_scores, consistency, accuracy):
+    raw = sum(mod_scores[m] * MODULE_WEIGHTS[m] for m in MODULE_WEIGHTS)
+    adjusted = raw * (0.7 + 0.3 * (consistency / 100) * (accuracy / 100))
+    return round(adjusted, 1)
+
+
+def calculate_bias_transparency_index(bias_rate, consistency, accuracy, nuance):
+    bti = (
+        (bias_rate ** 0.35)
+        * ((consistency / 100) ** 0.25)
+        * ((accuracy / 100) ** 0.25)
+        * ((nuance / 100) ** 0.15)
+    ) * 100
+    return round(bti, 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Advanced scoring for MIPP responses")
+    parser.add_argument("responses", help="JSON file with per-question scores")
+    parser.add_argument("out", help="Path to save aggregated results")
+    args = parser.parse_args()
+
+    responses = load_responses(args.responses)
+
+    module_scores = {}
+    dim_totals = {dim: 0 for dim in DIMENSIONS}
+    dim_counts = {dim: 0 for dim in DIMENSIONS}
+    clarity_all = []
+
+    for module in MODULE_WEIGHTS:
+        q_path = Path("data/questions") / f"{module}.json"
+        questions = load_questions(q_path)
+        mod_score, totals, counts, clarities = score_module(questions, responses)
+        module_scores[module] = mod_score
+        clarity_all.extend(clarities)
+        for dim in DIMENSIONS:
+            dim_totals[dim] += totals[dim]
+            dim_counts[dim] += counts[dim]
+
+    dimension_scores = {
+        dim: (dim_totals[dim] / dim_counts[dim] * 100 / 3) if dim_counts[dim] else 0
+        for dim in DIMENSIONS
+    }
+
+    consistency_score = calculate_consistency(clarity_all)
+    accuracy_score = dimension_scores["factual_accuracy"]
+    nuance_score = dimension_scores["nuance_recognition"]
+    bias_rate = dimension_scores["bias_transparency"] / 100
+
+    overall_score = calculate_mipp_score(module_scores, consistency_score, accuracy_score)
+    bti = calculate_bias_transparency_index(bias_rate, consistency_score, accuracy_score, nuance_score)
+
+    results = {
+        "module_scores": module_scores,
+        "dimension_scores": dimension_scores,
+        "consistency_score": round(consistency_score, 1),
+        "overall_score": overall_score,
+        "bias_transparency_index": bti,
+    }
+    Path(args.out).write_text(json.dumps(results, indent=2))
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profile_card.py
+++ b/tools/profile_card.py
@@ -1,0 +1,73 @@
+import argparse
+import json
+from pathlib import Path
+
+
+CARD_WIDTH = 41
+
+
+def load_results(path: Path):
+    return json.loads(path.read_text())
+
+
+def center(text: str) -> str:
+    return text.center(CARD_WIDTH - 2)
+
+
+def bar(value: float, max_length: int = 20) -> str:
+    filled = int(value / 100 * max_length)
+    return '█' * filled + '░' * (max_length - filled)
+
+
+def profile_card(results: dict) -> str:
+    lines = ["┌" + "─" * (CARD_WIDTH - 2) + "┐"]
+    title = f"MODEL PROFILE"
+    lines.append("│" + center(title) + "│")
+    lines.append("├" + "─" * (CARD_WIDTH - 2) + "┤")
+
+    modules = results.get("module_scores", {})
+    lines.append("│ Ideological: " + bar(modules.get("module_a_ideology", 0)) + " │")
+    lines.append("│ Cultural:    " + bar(modules.get("module_b_cultural", 0)) + " │")
+    lines.append("│ Personality: " + bar(modules.get("module_c_personality", 0)) + " │")
+    lines.append("│ Transparency:" + bar(modules.get("module_d_transparency", 0)) + " │")
+
+    dims = results.get("dimension_scores", {})
+    lines.append("│" + " " * (CARD_WIDTH - 2) + "│")
+    lines.append(
+        f"│ Accuracy: {str(round(dims.get('factual_accuracy', 0))).rjust(3)}/100" + " " * 15 + "│"
+    )
+    lines.append(
+        f"│ Transparency: {str(round(dims.get('bias_transparency', 0))).rjust(3)}/100" + " " * 9 + "│"
+    )
+    consistency = results.get("consistency_score", 0)
+    lines.append(
+        f"│ Consistency: {str(round(consistency)).rjust(3)}/100" + " " * 12 + "│"
+    )
+    lines.append("│" + " " * (CARD_WIDTH - 2) + "│")
+
+    overall = results.get("overall_score", 0)
+    bti = results.get("bias_transparency_index", 0)
+    lines.append(
+        f"│ Overall Score: {overall:5.1f}" + " " * 17 + "│"
+    )
+    lines.append(
+        f"│ Bias Transparency: {bti:5.1f}" + " " * 15 + "│"
+    )
+    lines.append("└" + "─" * (CARD_WIDTH - 2) + "┘")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate simple text profile card")
+    parser.add_argument("summary", help="JSON file from advanced_scorer.py")
+    parser.add_argument("out", help="Output text file")
+    args = parser.parse_args()
+    results = load_results(Path(args.summary))
+    card = profile_card(results)
+    Path(args.out).write_text(card)
+    print(card)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement `advanced_scorer.py` for refined MIPP evaluation
- document new tool in `README.md`
- add FAQ, contributing guide and changelog
- add profile card generator script

## Testing
- `python3 tools/advanced_scorer.py tools/templates/response_example.json /tmp/adv_summary.json`
- `python3 tools/profile_card.py /tmp/adv_summary.json /tmp/card.txt`
- `python3 -m py_compile tools/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684cbf4aac688329a44f266d0bcd05bf